### PR TITLE
change mongo image tag to 5

### DIFF
--- a/kubernetes/database.yaml
+++ b/kubernetes/database.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: database
-          image: mongo:5.0
+          image: mongo:5
           ports:
             - containerPort: 27017
           resources:


### PR DESCRIPTION
Hey Tony,

I'm experiencing "ImagePullBackOff" errors deploying the app when the mongo image tag is "5.0". Setting it to "5" seemed to fix it at least in the context of the lab. 