### PR TITLE
Force python logging to output to stdout

### DIFF
--- a/v3/src/web/app.py
+++ b/v3/src/web/app.py
@@ -14,7 +14,7 @@ from waitress import serve
 
 app = Flask(__name__)
 metrics = PrometheusMetrics(app)
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
 host = os.getenv("HOST", "0.0.0.0")
 port = os.getenv("PORT", "8080")


### PR DESCRIPTION
Untested (having issues with skaffold). 

In theory, this should be the smallest change to fix #19 without implementing full structured logging